### PR TITLE
Increase time for graylog to configure

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -68,7 +68,7 @@
     status_code: 200,403
     timeout: 5
   register: graylog_service_status
-  retries: 10
+  retries: 15
   delay: 5
   until:
     - ('status' in graylog_service_status)


### PR DESCRIPTION
It happened that graylog has configured properly but given timeout (10 retries, 5s delay) was not enough to detect it .